### PR TITLE
Use plugins_url() instead of WP_PLUGIN_URL

### DIFF
--- a/easy-columns/easy-columns.php
+++ b/easy-columns/easy-columns.php
@@ -39,9 +39,9 @@ if(!class_exists("EasyColumns")){
 			if (!defined('EZC_PLUGIN_NAME'))
 				define('EZC_PLUGIN_NAME', trim(dirname(plugin_basename(__FILE__)), '/'));
 			if (!defined('EZC_PLUGIN_DIR'))
-				define('EZC_PLUGIN_DIR', WP_PLUGIN_DIR . '/' . EZC_PLUGIN_NAME);
+				define('EZC_PLUGIN_DIR', plugins_url() . '/' . EZC_PLUGIN_NAME);
 			if (!defined('EZC_PLUGIN_URL'))
-				define('EZC_PLUGIN_URL', WP_PLUGIN_URL . '/' . EZC_PLUGIN_NAME);
+				define('EZC_PLUGIN_URL', plugins_url() . '/' . EZC_PLUGIN_NAME);
 			if (!defined('EZC_PLUGIN_VERSION'))
 				define('EZC_PLUGIN_VERSION','2.1.1');
 			if (!defined('EZC_PLUGIN_TYPE'))


### PR DESCRIPTION
For https-only sites, using WP_PLUGIN_URL makes easy-columns.css a http download, causing a mixed-content error and a 404.

Instead, changing WP_PLUGIN_URL to plugins_url() will make easy-columns https-aware.

I could optionally add
```
if ( function_exists('plugins_url') )
```
and fall back to WP_PLUGIN_URL if you desire backwards-compatibility.  However, WP_PLUGIN_URL was deprecated on Monday, July 14, 2008 upon the release of Wordpress 2.6 (https://codex.wordpress.org/Version_2.6).  Since WP_PLUGIN_URL is still not https-aware, you might just want to pull the trigger on this one.